### PR TITLE
Don't add message when merging

### DIFF
--- a/merge.sh
+++ b/merge.sh
@@ -25,6 +25,6 @@ git submodule foreach git checkout -b $RESULTING_BRANCH
 git submodule foreach git merge origin/$BRANCH
 git checkout trunk
 git checkout -b $RESULTING_BRANCH
-git merge origin/$BRANCH
+git merge --no-edit origin/$BRANCH
 git add modules/*
 git commit --allow-empty -m "Select merge commits in submodules"


### PR DESCRIPTION
This script is executed only in docker when checking that the PR may be merged.

It may need to add some merge commits, but we don't want to have message for such commits (they won't be pushed anywhere).
